### PR TITLE
Fix readDocument 404

### DIFF
--- a/src/handler/read-document.js
+++ b/src/handler/read-document.js
@@ -14,7 +14,10 @@ module.exports = (
     .read();
   if (!data) {
     res.statusCode = 404;
-    return {};
+    return {
+        code: "NotFound",
+        message: "Entity with the specified id does not exist in the system.,"
+    };
   }
 
   return data;


### PR DESCRIPTION
We always expect a response when there is a 404 in cosmos and the cosmos mock is returning an empty object that makes the client break when this happens. This PR updates that case.