### PR TITLE
Fix Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,8 @@ async function runClient() {
   });
 
   // initialize databases since the server is always empty when it boots
-  const { database } = await client.databases.createIfNotExists({
-    id: "test-db"
-  });
-  const { container } = await database.containers.createIfNotExists({
-    id: "test-container"
-  });
+  const { database } = await client.databases.createIfNotExists({ id: 'test-db' });
+  const { container } = await database.containers.createIfNotExists({ id: 'test-container' });
 
   // use the client
   // ...

--- a/README.md
+++ b/README.md
@@ -3,12 +3,9 @@
 A Cosmos DB server implementation for testing your apps locally.
 
 ```js
-const { default: cosmosServer } = require('@zeit/cosmosdb-server');
-const { CosmosClient } = require('@azure/cosmos');
-
-// disable SSL verification
-// since the server uses self-signed certificate
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+const { default: cosmosServer } = require("@zeit/cosmosdb-server");
+const { CosmosClient } = require("@azure/cosmos");
+const https = require("https");
 
 cosmosServer().listen(3000, () => {
   console.log(`Cosmos DB server running at https://localhost:3000`);
@@ -19,16 +16,23 @@ cosmosServer().listen(3000, () => {
 async function runClient() {
   const client = new CosmosClient({
     endpoint: `https://localhost:3000`,
-    key: "dummy key"
+    key: "dummy key",
+    // disable SSL verification
+    // since the server uses self-signed certificate
+    agent: https.Agent({ rejectUnauthorized: false })
   });
 
   // initialize databases since the server is always empty when it boots
-  const { database } = await client.databases.createIfNotExists({ id: 'test-db' });
-  const { container } = await database.containers.createIfNotExists({ id: 'test-container' });
+  const { database } = await client.databases.createIfNotExists({
+    id: "test-db"
+  });
+  const { container } = await database.containers.createIfNotExists({
+    id: "test-container"
+  });
 
   // use the client
   // ...
-});
+}
 ```
 
 To run the server on cli:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "path-to-regexp": "3.1.0",
     "big-integer": "1.6.46",
     "int64-buffer": "0.99.1007",
-    "path-to-regexp": "3.1.0",
     "raw-body": "2.4.1",
     "uuid": "3.3.3"
   },


### PR DESCRIPTION
This PR removes the `NODE_TLS_REJECT_UNAUTHORIZED` env variable as it causes a warning:
`(node:27515) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.`

`CosmosClient` accepts an (optional) additional http agent that can be configured as we like. 
Creating `CosmosClient` like this:
```js
  const client = new CosmosClient({
    endpoint: `https://localhost:3000`,
    key: "dummy key",
    // disable SSL verification
    // since the server uses self-signed certificate
    agent: https.Agent({ rejectUnauthorized: false })
  });
```
 solves the TLS "issue" and avoids the warning.

Also, I was not able to do unit tests with  `NODE_TLS_REJECT_UNAUTHORIZED` var. However, after creating `CosmosClient` with a custom `agent` it worked well.

PS: The `package.json` also had repeared `path-to-regexp` entries. I've removed the duplicate