### PR TITLE
Allow options to be customized

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ const options = {
   requestCert: false
 };
 
+export const configure = (opts: typeof options) => Object.assign(options, opts)
+
 export default () => {
   const account = new Account();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { readFileSync } from "fs";
-import { createServer } from "https";
+import { createServer, ServerOptions } from "https";
 import { join } from "path";
 import * as tls from "tls";
 import uuid from "uuid/v4";
 import Account from "./account";
 import routes from "./routes";
 
-const options = {
+const options: ServerOptions = {
   cert: readFileSync(join(__dirname, "..", "cert.pem")),
   key: readFileSync(join(__dirname, "..", "key.pem")),
   minVersion: "TLSv1" as tls.SecureVersion,
@@ -14,7 +14,7 @@ const options = {
   requestCert: false
 };
 
-export const configure = (opts: Partial<typeof options>) => Object.assign(options, opts)
+export const configure = (opts: ServerOptions) => Object.assign(options, opts)
 
 export default () => {
   const account = new Account();

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,10 @@ const options: ServerOptions = {
   requestCert: false
 };
 
-export const configure = (opts: ServerOptions) => Object.assign(options, opts)
-
-export default () => {
+export default (opts?: ServerOptions) => {
   const account = new Account();
 
-  return createServer(options, (req, res) => {
+  return createServer({...options, ...opts}, (req, res) => {
     const route = routes(req);
 
     (async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const options = {
   requestCert: false
 };
 
-export const configure = (opts: typeof options) => Object.assign(options, opts)
+export const configure = (opts: Partial<typeof options>) => Object.assign(options, opts)
 
 export default () => {
   const account = new Account();


### PR DESCRIPTION
This would allow
```js
const { default: cosmosServer } = require("@zeit/cosmosdb-server");

cosmosServer({ cert: 'custom cert', key: 'custom key' }).listen(3000, () => {});
```

context I think your keys need to be more complex, or I prefer to use mine
```
curl: (60) SSL certificate problem: EE certificate key too weak
More details here: https://curl.haxx.se/docs/sslcerts.html
```