### PR TITLE
Check partition header when querying documents

### DIFF
--- a/src/handler/query-documents.ts
+++ b/src/handler/query-documents.ts
@@ -4,6 +4,7 @@ import readItems from "./_read-items";
 import Account from "../account";
 import json from "../json";
 import trueHeader from "../true-header";
+import getPartitionFromHeader from "../utils/get-partition-from-header";
 
 export default async (
   account: Account,
@@ -29,7 +30,7 @@ export default async (
     if (!trueHeader(req, "x-ms-documentdb-query-enablecrosspartition")) {
       const { partitionKey }: { partitionKey?: any } = collection.read() || {};
       const paths = (partitionKey || {}).paths || [];
-      if (paths.length && !query(body.query).containsPartitionKeys(paths)) {
+      if (paths.length && !query(body.query).containsPartitionKeys(paths) && !getPartitionFromHeader(req)) {
         res.statusCode = 400;
         return { message: "missing partition keys" };
       }


### PR DESCRIPTION
When we specify PartitionKey in QueryRequestOptions in c# sdk, it does not require the query string contains partition key condition. Instead, it sends the http header "x-ms-documentdb-partitionkey".
```cs
using var query = _container.GetItemQueryIterator<ProductInCosmos>(
                "SELECT * FROM c WHERE c.age < 10",
                requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey("Student") });
```
This PR is to check http header when querying documents. If the partition key value is provided in header, do not return 400