### PR TITLE
Strip all trailing slashes from request pathname

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -19,6 +19,10 @@ export default (rules: { [x: string]: { [y: string]: Function } }) => {
     if (pathname && pathname.slice(0, 2) === "//") {
       pathname = pathname.slice(1);
     }
+    // strip trailing slashes
+    while (pathname && pathname.length > 1 && pathname.endsWith("/")) {
+      pathname = pathname.slice(0, -1);
+    }
 
     let { method } = req;
     if (

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,0 +1,53 @@
+import * as http from "http";
+import router from "../src/router";
+
+function fakeReq(method: string, url: string): http.IncomingMessage {
+  return ({ method, url, headers: {} } as unknown) as http.IncomingMessage;
+}
+
+const handler = () => {};
+
+const match = router({
+  GET: {
+    "/dbs/:db_id": handler,
+    "/dbs/:db_id/colls/:coll_id": handler
+  }
+});
+
+describe("router", () => {
+  it("matches a path without trailing slash", () => {
+    const result = match(fakeReq("GET", "/dbs/mydb"));
+    expect(result).toBeDefined();
+    expect(result![0]).toEqual({ db_id: "mydb" });
+  });
+
+  it("matches a path with a single trailing slash", () => {
+    const result = match(fakeReq("GET", "/dbs/mydb/"));
+    expect(result).toBeDefined();
+    expect(result![0]).toEqual({ db_id: "mydb" });
+  });
+
+  it("matches a path with multiple trailing slashes", () => {
+    const result = match(fakeReq("GET", "/dbs/mydb///"));
+    expect(result).toBeDefined();
+    expect(result![0]).toEqual({ db_id: "mydb" });
+  });
+
+  it("matches a nested path with trailing slash", () => {
+    const result = match(fakeReq("GET", "/dbs/mydb/colls/mycoll/"));
+    expect(result).toBeDefined();
+    expect(result![0]).toEqual({ db_id: "mydb", coll_id: "mycoll" });
+  });
+
+  it("does not strip the root slash", () => {
+    const rootMatch = router({ GET: { "/": handler } });
+    const result = rootMatch(fakeReq("GET", "/"));
+    expect(result).toBeDefined();
+  });
+
+  it("matches a double-slash path", () => {
+    const result = match(fakeReq("GET", "//dbs/mydb"));
+    expect(result).toBeDefined();
+    expect(result![0]).toEqual({ db_id: "mydb" });
+  });
+});


### PR DESCRIPTION
Some clients add trailing slashes to request URLs, which causes route
matching to fail.   Real Cosmos is ambivalent about trailing slashes, so
we should be too.
