### PR TITLE
bump path-to-regexp to 8.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "big-integer": "1.6.46",
     "int64-buffer": "0.99.1007",
     "lru-cache": "6.0.0",
-    "path-to-regexp": "3.3.0",
+    "path-to-regexp": "8.4.1",
     "raw-body": "2.4.1"
   },
   "devDependencies": {

--- a/src/path-match.ts
+++ b/src/path-match.ts
@@ -1,8 +1,7 @@
-import pathToRegexp from "path-to-regexp";
+import { pathToRegexp } from "path-to-regexp";
 
 export default (path: string, opts?: {}) => {
-  const keys: any[] = [];
-  const regexp = pathToRegexp(path, keys, opts);
+  const { regexp, keys } = pathToRegexp(path, opts);
 
   return (pathname: string) => {
     const m = regexp.exec(pathname);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4779,10 +4779,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.3.0.tgz#f7f31d32e8518c2660862b644414b6d5c63a611b"
-  integrity sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==
+path-to-regexp@8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.4.1.tgz#1dbe9c340367a44340e5bc114f515b56c7210f19"
+  integrity sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==
 
 path-type@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Vulnerability in the package `path-to-regexp`

CVE-2026-4867
- https://cvefeed.io/vuln/detail/CVE-2026-4867
- https://nvd.nist.gov/vuln/detail/CVE-2026-4867
- https://app.opencve.io/cve/CVE-2026-4867



